### PR TITLE
Switch Style::create to use Into<String>

### DIFF
--- a/css-in-rust/examples/yew-integration/src/main.rs
+++ b/css-in-rust/examples/yew-integration/src/main.rs
@@ -17,16 +17,14 @@ impl Component for CustomComponent {
 
     fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
         let style = Style::create(
-            String::from("CustomComponent"),
-            String::from(
-                r#"
-                background-color: red;
-                .on-da-inside {
-                    background-color: blue;
-                    width: 100px
-                }
-                "#,
-            ),
+            "CustomComponent",
+            r#"
+            background-color: red;
+            .on-da-inside {
+                background-color: blue;
+                width: 100px
+            }
+            "#,
         );
         CustomComponent { style }
     }

--- a/css-in-rust/src/style/mod.rs
+++ b/css-in-rust/src/style/mod.rs
@@ -79,7 +79,8 @@ pub struct Style {
 #[cfg(target_arch = "wasm32")]
 impl Style {
     /// Creates a new style and, stores it into the registry and returns the
-    pub fn create(class_name: String, css: String) -> Style {
+    pub fn create<I1: Into<String>, I2: Into<String>>(class_name: I1, css: I2) -> Style {
+        let (class_name, css) = (class_name.into(), css.into());
         let small_rng = SmallRng::from_entropy();
         let mut new_style = Self {
             class_name: format!(
@@ -194,7 +195,8 @@ impl Style {
 #[cfg(not(target_arch = "wasm32"))]
 impl Style {
     /// Creates a new style and, stores it into the registry and returns the
-    pub fn create(class_name: String, css: String) -> Style {
+    pub fn create<I1: Into<String>, I2: Into<String>>(class_name: I1, css: I2) -> Style {
+        let (class_name, css) = (class_name.into(), css.into());
         let small_rng = SmallRng::from_entropy();
         let new_style = Self {
             class_name: format!(


### PR DESCRIPTION
## Reasoning 

This, in certain scenarios, removes unnecessary allocations and also allows for a cleaner API (i.e. not having to wrap string literals or other &str's in String::new). Should be entirely backwards compatible.

Also curious: is there a reason why it is Style::create as opposed to Style::new? (as Style::new would be a bit more idiomatic and a negligible about of keystrokes shorter)

## Examples of where this would improve it:

Example (your example, to be specific) of less typing (but produces identical code to before w/ any level of optimization):
```rust
let style = Style::create(
    "CustomComponent",
    r#"
    background-color: red;
    .on-da-inside {
        background-color: blue;
        width: 100px
    }
    "#,
);
```

While I don't have an example handy, any type that has an `Into<String>` impl that is an in-place conversion, it would save an allocation (albeit the is assuming the user doesn't also use `.into()`)